### PR TITLE
Image from 2024 ngff challenge

### DIFF
--- a/metadata/register.py
+++ b/metadata/register.py
@@ -132,7 +132,10 @@ def load_attrs(uri, transport_params=None, extension=None):
                 with open(path) as f:
                     zattrs = json.load(f)
             if "attributes" in zattrs:
-                zattrs = zattrs["attributes"]["ome"]
+                zattrs_ome = zattrs["attributes"].get("ome")
+                if zattrs_ome is None:
+                    return zattrs
+                zattrs = zattrs_ome
             return zattrs
         except Exception as e:
             pass


### PR DESCRIPTION
Handle file without .zarray and info in zarr.json (not under ome)
Images from the 2024 ngff challenge fail to register
* The images do not have  the ``.zarray`` file we rely on to discover shapes and pixels type
* Information is stored in ``zarr.json`` but not under ``attributes/ome``.

Check that files from IDR catalog and  2024 ngff challenge can be registered

A file from challenge that failed to register without this PR 
```
python register.py s3://idr/share/ome2024-ngff-challenge/idr0066/ExpB_whole_cns_MIP.ome.zarr --endpoint https://uk1s3.embassy.ebi.ac.uk  --nosignrequest
```