### PR TITLE
Use zarr-python to load zarr groups and arrays

### DIFF
--- a/metadata/register.py
+++ b/metadata/register.py
@@ -94,7 +94,7 @@ def parse_image_metadata(store, img_attrs, image_path=None):
     multiscale_attrs = img_attrs['multiscales'][0]
     array_path = multiscale_attrs["datasets"][0]["path"]
     if image_path is not None:
-        array_path = f"{image_path.rstrip("/")}/{array_path}"
+        array_path = f"{image_path}.rstrip("/")/{array_path}"
     # load .zarray from path to know the dimension
     array_data = load_array(store, array_path)
     sizes = {}
@@ -427,7 +427,7 @@ def set_external_info(image, args, image_path=None):
     nosignrequest = args.nosignrequest
 
     if image_path is not None:
-        uri = f"{uri.rstrip("/")}/{image_path}"
+        uri = f"{uri}.rstrip("/")/{image_path}"
     parsed_uri = urlsplit(uri)
     scheme = "{0.scheme}".format(parsed_uri)
 

--- a/metadata/register.py
+++ b/metadata/register.py
@@ -274,6 +274,8 @@ def register_image(conn, store, args, img_attrs=None, image_path=None):
         image_name = img_attrs["name"]
     else:
         image_name = args.uri.rstrip("/").split("/")[-1]
+        if image_path is not None:
+            image_name = f"{image_name} [{image_path}]"
     image, rnd_def = create_image(conn, store, img_attrs, image_name, families, models, args, image_path=image_path)
     update_service.saveAndReturnObject(image)
     update_service.saveAndReturnObject(rnd_def)

--- a/metadata/register.py
+++ b/metadata/register.py
@@ -94,7 +94,7 @@ def parse_image_metadata(store, img_attrs, image_path=None):
     multiscale_attrs = img_attrs['multiscales'][0]
     array_path = multiscale_attrs["datasets"][0]["path"]
     if image_path is not None:
-        array_path = f"{image_path}.rstrip("/")/{array_path}"
+        array_path = image_path.rstrip("/") + "/" + array_path
     # load .zarray from path to know the dimension
     array_data = load_array(store, array_path)
     sizes = {}
@@ -427,7 +427,7 @@ def set_external_info(image, args, image_path=None):
     nosignrequest = args.nosignrequest
 
     if image_path is not None:
-        uri = f"{uri}.rstrip("/")/{image_path}"
+        uri = uri.rstrip("/") + "/" + image_path
     parsed_uri = urlsplit(uri)
     scheme = "{0.scheme}".format(parsed_uri)
 


### PR DESCRIPTION
This uses `zarr-python v3.0.+` to handle loading of `attrs` and `arrays` instead of manually loading `.zattrs` etc.
It should work with zarr v3 without any significant changes.
Doesn't need boto or smart_open.

We basically create a zarr store with the args, then pass that around for loading zattrs and arrays.
The args are also passed to `set_external_info()` for use in generating the `lsid`.

Not tested with aws credentials yet - Don't know how (no amazon aws account) or have any such samples.

New: ALL series within bioformats2raw.layout are now registered.

To test:

 - install zarr: `pip install zarr`
 - Create a new Dataset (on merge-ci), then import images listed at https://github.com/BioNGFF/omero-import-utils/issues/13

Known issues: 

 - This image is not viewable in OMERO (not due to this PR - also broken in `main`. Same lsid in both):
```
$ python register.py --target 21520 https://data.source.coop/joshmoore/idr-ome-ngff-samples/v0.4/idr0062A/6001240.zarr
lsid: s3://data.source.coop/joshmoore/idr-ome-ngff-samples/v0.4/idr0062A/6001240.zarr/?anonymous=true
```

 - Saving of Rendering Settings in the webclient seems to be failing for ALL registered images - also not due to this PR.