### PR TITLE
Fix save rdef. set rdef.version

### DIFF
--- a/metadata/register.py
+++ b/metadata/register.py
@@ -181,6 +181,7 @@ def set_rendering_settings(omero_info, pixels_type, pixels_id, families, models)
     if rdefs is None:
         rdefs = dict()
     rnd_def = omero.model.RenderingDefI()
+    rnd_def.version = rint(0)
     rnd_def.defaultZ = rint(rdefs.get('defaultZ', 0))
     rnd_def.defaultT = rint(rdefs.get('defaultT', 0))
     value = rdefs.get('model', 'rgb')


### PR DESCRIPTION
Fixes #18.

Blitz.log on failure to save rendering settings has

```
2025-07-28 09:52:38,998 INFO  [                 org.perf4j.TimingLogger] (.Server-13) start[1753696358988] time[9] tag[omero.call.exception]
2025-07-28 09:52:38,998 WARN  [        ome.services.util.ServiceHandler] (.Server-13) Unknown exception thrown.

java.lang.NullPointerException: null
	at ome.services.RenderingBean.internalSave(RenderingBean.java:925)
	at ome.services.RenderingBean.saveCurrentSettings(RenderingBean.java:869)
	at jdk.internal.reflect.GeneratedMethodAccessor2337.invoke(Unknown Source)
```

Comes from `old.getVersion()` at
https://github.com/ome/omero-server/blob/e594cc1fccbdaffe1c51566d8c5b1d4d4da49d69/src/main/java/ome/services/RenderingBean.java#L925

Seems that although `rdef.version` is "optional" at https://omero.readthedocs.io/en/stable/developers/Model/EveryObject.html#renderingdef the `RenderingBean` does expect it.

This fixes the issue by simply setting the `rdef.version` when it gets created.

To test, create an image with `register.py`, (e.g. `python register.py --target 21520 https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr` then try to save new settings in the webclient.

cc @jburel @dominikl 