### PR TITLE
Always set cb.inputStart/inputEnd

### DIFF
--- a/metadata/register.py
+++ b/metadata/register.py
@@ -238,10 +238,15 @@ def set_rendering_settings(omero_info, pixels_type, pixels_id, families, models)
         cb.alpha = rint(255)
         cb.noiseReduction = rbool(False)
 
-        window = entry.get("window", None)
-        if window:
-            cb.inputStart = rdouble(window.get("start", pixels_min))
-            cb.inputEnd = rdouble(window.get("end", pixels_max))
+        window = entry.get("window", {})
+        try:
+            cb.inputStart = rdouble(float(window.get("start", pixels_min)))
+        except TypeError:
+            cb.inputStart = rdouble(pixels_min)
+        try:
+            cb.inputEnd = rdouble(float(window.get("end", pixels_max)))
+        except TypeError:
+            cb.inputEnd = rdouble(pixels_max)
         inverted = entry.get("inverted", False)
         if inverted: # add codomain
             ric = omero.model.ReverseIntensityContextI()


### PR DESCRIPTION
Handle missing channel window: always set `cb.inputStart/inputEnd`.

E.g. https://uk1s3.embassy.ebi.ac.uk/idr/share/microscopynodes/20250730/FIBSEM_dino_masks.zarr/ has missing `omero.channel.window` - see https://ome.github.io/ome-ngff-validator/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/microscopynodes/20250730/FIBSEM_dino_masks.zarr/

which previously caused `register.py` to fail with 

```
    serverStackTrace = ome.conditions.ValidationException: not-null property references a null or transient value: ome.model.display.ChannelBinding.inputEnd; nested exception is org.hibernate.PropertyValueException: not-null property references a null or transient value: ome.model.display.ChannelBinding.inputEnd
	at org.springframework.orm.hibernate3.SessionFactoryUtils.convertHibernateAccessException(SessionFactoryUtils.java:681)
	at org.springframework.orm.hibernate3.HibernateAccessor.convertHibernateAccessException(HibernateAccessor.java:416)
```
